### PR TITLE
Update VPC, subnet, and IGW Name tags to 'openly-eks-demo'

### DIFF
--- a/examples/eks-getting-started/vpc.tf
+++ b/examples/eks-getting-started/vpc.tf
@@ -13,7 +13,7 @@ resource "aws_vpc" "demo" {
   cidr_block = "10.0.0.0/16"
 
   tags = tomap({
-    "Name"                                      = "terraform-eks-demo-node",
+    "Name"                                      = "openly-eks-demo",
     "kubernetes.io/cluster/${var.cluster_name}" = "shared",
   })
 }
@@ -27,7 +27,7 @@ resource "aws_subnet" "demo" {
   vpc_id                  = aws_vpc.demo.id
 
   tags = tomap({
-    "Name"                                      = "terraform-eks-demo-node",
+    "Name"                                      = "openly-eks-demo",
     "kubernetes.io/cluster/${var.cluster_name}" = "shared",
   })
 }
@@ -36,7 +36,7 @@ resource "aws_internet_gateway" "demo" {
   vpc_id = aws_vpc.demo.id
 
   tags = {
-    Name = "terraform-eks-demo"
+    Name = "openly-eks-demo"
   }
 }
 


### PR DESCRIPTION
This PR updates the Name tags in vpc.tf to 'openly-eks-demo' for VPC, subnets, and internet gateway resources as requested.