### PR TITLE
Update all AWS VPC tags to Opsly-subham

### DIFF
--- a/examples/eks-getting-started/vpc.tf
+++ b/examples/eks-getting-started/vpc.tf
@@ -13,8 +13,8 @@ resource "aws_vpc" "demo" {
   cidr_block = "10.0.0.0/16"
 
   tags = tomap({
-    "Name"                                      = "terraform-eks-demo-node",
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+    "Name"                                      = "Opsly-subham",
+    "kubernetes.io/cluster/${var.cluster_name}" = "Opsly-subham",
   })
 }
 
@@ -27,8 +27,8 @@ resource "aws_subnet" "demo" {
   vpc_id                  = aws_vpc.demo.id
 
   tags = tomap({
-    "Name"                                      = "terraform-eks-demo-node",
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+    "Name"                                      = "Opsly-subham",
+    "kubernetes.io/cluster/${var.cluster_name}" = "Opsly-subham",
   })
 }
 
@@ -36,7 +36,7 @@ resource "aws_internet_gateway" "demo" {
   vpc_id = aws_vpc.demo.id
 
   tags = {
-    Name = "terraform-eks-demo"
+    Name = "Opsly-subham"
   }
 }
 

--- a/examples/networking/region/vpc.tf
+++ b/examples/networking/region/vpc.tf
@@ -3,8 +3,14 @@
 
 resource "aws_vpc" "main" {
   cidr_block = cidrsubnet(var.base_cidr_block, 4, var.region_numbers[var.region])
+  tags = {
+    Name = "Opsly-subham"
+  }
 }
 
 resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "Opsly-subham"
+  }
 }

--- a/examples/opensearchserverless/vpc.tf
+++ b/examples/opensearchserverless/vpc.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "vpc" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = "example-vpc"
+    Name = "Opsly-subham"
   }
 }
 
@@ -17,7 +17,7 @@ resource "aws_subnet" "subnet" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "example-subnet"
+    Name = "Opsly-subham"
   }
 }
 
@@ -26,7 +26,7 @@ resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.vpc.id
 
   tags = {
-    Name = "example-igw"
+    Name = "Opsly-subham"
   }
 }
 
@@ -50,7 +50,7 @@ resource "aws_route_table_association" "route_table_association" {
 resource "aws_security_group" "security_group" {
   vpc_id = aws_vpc.vpc.id
   tags = {
-    Name = "example-security-group"
+    Name = "Opsly-subham"
   }
 }
 

--- a/examples/transit-gateway-cross-account-vpc-attachment/main.tf
+++ b/examples/transit-gateway-cross-account-vpc-attachment/main.tf
@@ -37,7 +37,7 @@ resource "aws_ec2_transit_gateway" "example" {
   provider = aws.first
 
   tags = {
-    Name = "terraform-example"
+    Name = "Opsly-subham"
   }
 }
 
@@ -47,7 +47,7 @@ resource "aws_ram_resource_share" "example" {
   name = "terraform-example"
 
   tags = {
-    Name = "terraform-example"
+    Name = "Opsly-subham"
   }
 }
 
@@ -73,7 +73,7 @@ resource "aws_vpc" "example" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-example"
+    Name = "Opsly-subham"
   }
 }
 
@@ -85,7 +85,7 @@ resource "aws_subnet" "example" {
   vpc_id            = aws_vpc.example.id
 
   tags = {
-    Name = "terraform-example"
+    Name = "Opsly-subham"
   }
 }
 
@@ -103,7 +103,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "example" {
   vpc_id             = aws_vpc.example.id
 
   tags = {
-    Name = "terraform-example"
+    Name = "Opsly-subham"
     Side = "Creator"
   }
 }
@@ -115,7 +115,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
   transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.example.id
 
   tags = {
-    Name = "terraform-example"
+    Name = "Opsly-subham"
     Side = "Accepter"
   }
 }

--- a/examples/transit-gateway-intra-region-peering/main.tf
+++ b/examples/transit-gateway-intra-region-peering/main.tf
@@ -14,7 +14,7 @@ resource "aws_vpc" "example_vpc_1" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-example-vpc-1"
+    Name = "Opsly-subham"
   }
 }
 
@@ -23,7 +23,7 @@ resource "aws_subnet" "example_subnet_1" {
   vpc_id     = aws_vpc.example_vpc_1.id
 
   tags = {
-    Name = "terraform-example-subnet-1"
+    Name = "Opsly-subham"
   }
 }
 
@@ -31,7 +31,7 @@ resource "aws_vpc" "example_vpc_2" {
   cidr_block = "10.2.0.0/16"
 
   tags = {
-    Name = "terraform-example-vpc-2"
+    Name = "Opsly-subham"
   }
 }
 
@@ -40,14 +40,14 @@ resource "aws_subnet" "example_subnet_2" {
   vpc_id     = aws_vpc.example_vpc_2.id
 
   tags = {
-    Name = "terraform-example-subnet-2"
+    Name = "Opsly-subham"
   }
 }
 
 # Create the first Transit Gateway.
 resource "aws_ec2_transit_gateway" "example_tgw_1" {
   tags = {
-    Name = "terraform-example-tgw-1"
+    Name = "Opsly-subham"
   }
 }
 
@@ -58,14 +58,14 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "example_vpc_1_attachment" {
   vpc_id             = aws_vpc.example_vpc_1.id
 
   tags = {
-    Name = "terraform-example-vpc-attach-1"
+    Name = "Opsly-subham"
   }
 }
 
 # Create the second Transit Gateway in the same region.
 resource "aws_ec2_transit_gateway" "example_tgw_2" {
   tags = {
-    Name = "terraform-example-tgw-2"
+    Name = "Opsly-subham"
   }
 }
 
@@ -76,7 +76,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "example_vpc_2_attachment" {
   vpc_id             = aws_vpc.example_vpc_2.id
 
   tags = {
-    Name = "terraform-example-vpc-attach-2"
+    Name = "Opsly-subham"
   }
 }
 
@@ -88,7 +88,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "example_source_peering" {
   transit_gateway_id      = aws_ec2_transit_gateway.example_tgw_1.id
   peer_transit_gateway_id = aws_ec2_transit_gateway.example_tgw_2.id
   tags = {
-    Name = "terraform-example-tgw-peering"
+    Name = "Opsly-subham"
     Side = "Creator"
   }
 }
@@ -107,7 +107,7 @@ data "aws_ec2_transit_gateway_peering_attachment" "example_accepter_peering_data
 resource "aws_ec2_transit_gateway_peering_attachment_accepter" "example_accepter" {
   transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.example_accepter_peering_data.id
   tags = {
-    Name = "terraform-example-tgw-peering-accepter"
+    Name = "Opsly-subham"
     Side = "Acceptor"
   }
 }


### PR DESCRIPTION
This PR updates all possible AWS VPC-related resource tags to 'Opsly-subham'.