### PR TITLE
Increase EKS node group max_size to 5

### DIFF
--- a/examples/eks-getting-started/eks-worker-nodes.tf
+++ b/examples/eks-getting-started/eks-worker-nodes.tf
@@ -49,7 +49,7 @@ resource "aws_eks_node_group" "demo" {
 
   scaling_config {
     desired_size = 1
-    max_size     = 1
+    max_size     = 5
     min_size     = 1
   }
 


### PR DESCRIPTION
This PR updates the scaling_config in eks-worker-nodes.tf to set max_size = 5 (previously 1), allowing the EKS node group to scale up to 5 nodes.