### PR TITLE
Add 'subham' tag to all EKS-related Terraform resources

### DIFF
--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -25,6 +25,11 @@ resource "aws_iam_role" "demo-cluster" {
   ]
 }
 POLICY
+
+  tags = {
+    Name    = "terraform-eks-demo-cluster-role"
+    subham  = "true"
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSClusterPolicy" {
@@ -50,7 +55,8 @@ resource "aws_security_group" "demo-cluster" {
   }
 
   tags = {
-    Name = "terraform-eks-demo"
+    Name   = "terraform-eks-demo"
+    subham = "true"
   }
 }
 
@@ -71,6 +77,11 @@ resource "aws_eks_cluster" "demo" {
   vpc_config {
     security_group_ids = [aws_security_group.demo-cluster.id]
     subnet_ids         = aws_subnet.demo[*].id
+  }
+
+  tags = {
+    Name   = "terraform-eks-demo-cluster"
+    subham = "true"
   }
 
   depends_on = [

--- a/examples/eks-getting-started/eks-worker-nodes.tf
+++ b/examples/eks-getting-started/eks-worker-nodes.tf
@@ -24,6 +24,11 @@ resource "aws_iam_role" "demo-node" {
   ]
 }
 POLICY
+
+  tags = {
+    Name   = "terraform-eks-demo-node-role"
+    subham = "true"
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "demo-node-AmazonEKSWorkerNodePolicy" {
@@ -51,6 +56,11 @@ resource "aws_eks_node_group" "demo" {
     desired_size = 1
     max_size     = 1
     min_size     = 1
+  }
+
+  tags = {
+    Name   = "terraform-eks-demo-node-group"
+    subham = "true"
   }
 
   depends_on = [

--- a/examples/eks-getting-started/vpc.tf
+++ b/examples/eks-getting-started/vpc.tf
@@ -15,6 +15,7 @@ resource "aws_vpc" "demo" {
   tags = tomap({
     "Name"                                      = "terraform-eks-demo-node",
     "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+    "subham"                                    = "true",
   })
 }
 
@@ -29,6 +30,7 @@ resource "aws_subnet" "demo" {
   tags = tomap({
     "Name"                                      = "terraform-eks-demo-node",
     "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+    "subham"                                    = "true",
   })
 }
 
@@ -36,7 +38,8 @@ resource "aws_internet_gateway" "demo" {
   vpc_id = aws_vpc.demo.id
 
   tags = {
-    Name = "terraform-eks-demo"
+    Name   = "terraform-eks-demo"
+    subham = "true"
   }
 }
 
@@ -46,6 +49,11 @@ resource "aws_route_table" "demo" {
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.demo.id
+  }
+
+  tags = {
+    Name   = "terraform-eks-demo-route-table"
+    subham = "true"
   }
 }
 


### PR DESCRIPTION
## Summary
This pull request adds the `subham` tag to all EKS-related Terraform resources for better resource identification and management.

## Changes Made
- **EKS Cluster Resources** (`eks-cluster.tf`):
  - Added `subham = "true"` tag to `aws_iam_role.demo-cluster`
  - Added `subham = "true"` tag to `aws_security_group.demo-cluster`
  - Added `subham = "true"` tag to `aws_eks_cluster.demo`

- **EKS Worker Node Resources** (`eks-worker-nodes.tf`):
  - Added `subham = "true"` tag to `aws_iam_role.demo-node`
  - Added `subham = "true"` tag to `aws_eks_node_group.demo`

- **VPC and Network Resources** (`vpc.tf`):
  - Added `subham = "true"` tag to `aws_vpc.demo`
  - Added `subham = "true"` tag to `aws_subnet.demo` resources
  - Added `subham = "true"` tag to `aws_internet_gateway.demo`
  - Added `subham = "true"` tag to `aws_route_table.demo`

## Benefits
- Improved resource tracking and identification
- Enhanced cost allocation and billing transparency
- Better compliance with tagging standards
- Easier resource management and filtering

## Testing
These changes only add tags to existing resources and do not modify any functional configuration. The infrastructure behavior remains unchanged.

## Files Modified
- `examples/eks-getting-started/eks-cluster.tf`
- `examples/eks-getting-started/eks-worker-nodes.tf`
- `examples/eks-getting-started/vpc.tf`